### PR TITLE
Bug 1779585 - Cast version numbers to a number.

### DIFF
--- a/public_data_report/annotations/annotations.py
+++ b/public_data_report/annotations/annotations.py
@@ -62,7 +62,7 @@ def main(date_to, output_bucket, output_prefix):
                 latest_version_per_day AS (
                     SELECT
                         day,
-                        MAX(SPLIT(build.target.version, '.')[OFFSET(0)]) AS version
+                        MAX(`mozfun.norm.truncate_version`(build.target.version, "major")) AS version
                     FROM
                         `moz-fx-data-shared-prod.telemetry.buildhub2`
                     JOIN

--- a/scripts/public_data_report_user_activity.sql
+++ b/scripts/public_data_report_user_activity.sql
@@ -142,7 +142,7 @@ active_clients_weekly as (
     SELECT
         country_name,
         client_id,
-        split(app_version, '.')[offset(0)] as major_version,
+        `mozfun.norm.truncate_version`(app_version, "major") as major_version,
         date_sub(submission_date, interval days_since_seen DAY) as last_day_seen,
         week_start
     FROM
@@ -153,7 +153,7 @@ active_clients_weekly as (
 ),
 latest_releases AS (
     SELECT
-        MAX(SPLIT(build.target.version, '.')[OFFSET(0)]) AS latest_major_version,
+        MAX(`mozfun.norm.truncate_version`(build.target.version, "major")) AS latest_major_version,
         DATE(build.build.date) AS day
     FROM
         `moz-fx-data-shared-prod.telemetry.buildhub2`


### PR DESCRIPTION
Otherwise, this would compare strings to each other, and `MAX('100', '99')` is actually `99`.

Note that I can't really test this. I ran the query in BigQuery, and didn't see versions larger than 99 with the old query, but I do see them with the cast. I'm not sure if this actually fixes the public data report, but maybe it does. If someone could help verify that, that'd be awesome.