### PR TITLE
Emit 10.0.2xxxx for corresponding Windows builds

### DIFF
--- a/public_data_report/hardware_report/hardware_report.py
+++ b/public_data_report/hardware_report/hardware_report.py
@@ -56,9 +56,8 @@ def load_data(spark, date_from, date_to):
                 WHEN
                     environment.system.os.name = 'Windows_NT' and
                     environment.system.os.version = '10.0' and
-                    environment.system.os.windows_build_number >= 20000 and
-                    environment.system.os.windows_build_number < 30000
-                    THEN '10.0.2xxxx'
+                    environment.system.os.windows_build_number >= 10000
+                    THEN CONCAT('10.0.', CAST(CAST(environment.system.os.windows_build_number / 10000 AS INT64) AS STRING), 'xxxx')
                 ELSE environment.system.os.version
             END,
             'Other') AS os_version,

--- a/public_data_report/hardware_report/hardware_report.py
+++ b/public_data_report/hardware_report/hardware_report.py
@@ -57,7 +57,12 @@ def load_data(spark, date_from, date_to):
                     environment.system.os.name = 'Windows_NT' and
                     environment.system.os.version = '10.0' and
                     environment.system.os.windows_build_number >= 10000
-                    THEN CONCAT('10.0.', CAST(CAST(environment.system.os.windows_build_number / 10000 AS INT64) AS STRING), 'xxxx')
+                    THEN CONCAT(
+                        '10.0.',
+                        CAST(CAST(
+                            environment.system.os.windows_build_number / 10000 AS INT64
+                            ) AS STRING), 'xxxx'
+                        )
                 ELSE environment.system.os.version
             END,
             'Other') AS os_version,

--- a/public_data_report/hardware_report/hardware_report.py
+++ b/public_data_report/hardware_report/hardware_report.py
@@ -56,9 +56,9 @@ def load_data(spark, date_from, date_to):
                 WHEN
                     environment.system.os.name = 'Windows_NT' and
                     environment.system.os.version = '10.0' and
-                    environment.system.os.windows_build_number >= 22000 and
-                    environment.system.os.windows_build_number < 23000
-                    THEN '10.0.22xxx'
+                    environment.system.os.windows_build_number >= 20000 and
+                    environment.system.os.windows_build_number < 30000
+                    THEN '10.0.2xxxx'
                 ELSE environment.system.os.version
             END,
             'Other') AS os_version,

--- a/public_data_report/hardware_report/hardware_report.py
+++ b/public_data_report/hardware_report/hardware_report.py
@@ -50,9 +50,17 @@ def load_data(spark, date_from, date_to):
         COALESCE(environment.system.os.name,
             'Other') AS os_name,
         COALESCE(
-            IF (environment.system.os.name IN ('Linux', 'Darwin'),
-                CONCAT(REGEXP_EXTRACT(environment.system.os.version, r"^[0-9]+"), '.x'),
-                environment.system.os.version),
+            CASE
+                WHEN environment.system.os.name IN ('Linux', 'Darwin')
+                    THEN CONCAT(REGEXP_EXTRACT(environment.system.os.version, r"^[0-9]+"), '.x')
+                WHEN
+                    environment.system.os.name = 'Windows_NT' and
+                    environment.system.os.version = '10.0' and
+                    environment.system.os.windows_build_number >= 22000 and
+                    environment.system.os.windows_build_number < 23000
+                    THEN '10.0.22xxx'
+                ELSE environment.system.os.version
+            END,
             'Other') AS os_version,
         environment.system.memory_mb,
         coalesce(environment.system.is_wow64, FALSE) AS is_wow64,


### PR DESCRIPTION
Then the transposer can rename that into Windows 11 [here](https://github.com/mozilla/ensemble-transposer/blob/3a28e5da3f7f1211b8e96ae609ec68bbb87765df/config/datasets/hardware.json#L372-L375).

Fixes #11.