### PR TITLE
Use FLOOR() when processing Windows 10.0 versions

### DIFF
--- a/public_data_report/hardware_report/hardware_report.py
+++ b/public_data_report/hardware_report/hardware_report.py
@@ -60,7 +60,7 @@ def load_data(spark, date_from, date_to):
                     THEN CONCAT(
                         '10.0.',
                         CAST(CAST(
-                            environment.system.os.windows_build_number / 10000 AS INT64
+                            FLOOR(environment.system.os.windows_build_number / 10000) AS INT64
                             ) AS STRING), 'xxxx'
                         )
                 ELSE environment.system.os.version


### PR DESCRIPTION
Otherwise 25xxx becomes 3xxxx. (Sorry for not catching this early enough)