### PR TITLE
Treat WinNT 10.0.1xxxx as just 10.0

### DIFF
--- a/public_data_report/hardware_report/hardware_report.py
+++ b/public_data_report/hardware_report/hardware_report.py
@@ -56,7 +56,7 @@ def load_data(spark, date_from, date_to):
                 WHEN
                     environment.system.os.name = 'Windows_NT' and
                     environment.system.os.version = '10.0' and
-                    environment.system.os.windows_build_number >= 10000
+                    environment.system.os.windows_build_number >= 20000
                     THEN CONCAT(
                         '10.0.',
                         CAST(CAST(


### PR DESCRIPTION
I checked the data report and saw there are existing 10.0 and a newer 10.0.1xxxx. We can just merge the latter to the former so that we don't have to get two names for the same thing.