### PR TITLE
[DENG-2956][DENG-2894] Add Spain and Canada to static annotations

### DIFF
--- a/public_data_report/annotations/annotations.py
+++ b/public_data_report/annotations/annotations.py
@@ -109,7 +109,7 @@ def main(date_to, output_bucket, output_prefix):
     for static_annotation_file in STATIC_ANNOTATIONS:
         data = pkg_resources.read_text(static, static_annotation_file)
         blob_static_annotation = bucket.blob(f"{output_prefix}/{static_annotation_file}")
-        blob_static_annotation.upload_from_string(data)
+        blob_static_annotation.upload_from_string(data, content_type="application/json")
 
 
 if __name__ == '__main__':

--- a/public_data_report/annotations/static/annotations_webusage.json
+++ b/public_data_report/annotations/static/annotations_webusage.json
@@ -14,6 +14,21 @@
       "date": "2019-05-05"
     }
   ],
+  "Canada": [
+    {
+      "annotation": {
+        "pct_TP": "FF57",
+        "pct_addon": "legacy addons disabled"
+      },
+      "date": "2017-11-14"
+    },
+    {
+      "annotation": {
+        "pct_addon": "data deleted (addons outage)"
+      },
+      "date": "2019-05-05"
+    }
+  ],
   "China": [
     {
       "annotation": {
@@ -120,6 +135,21 @@
     }
   ],
   "Russia": [
+    {
+      "annotation": {
+        "pct_TP": "FF57",
+        "pct_addon": "legacy addons disabled"
+      },
+      "date": "2017-11-14"
+    },
+    {
+      "annotation": {
+        "pct_addon": "data deleted (addons outage)"
+      },
+      "date": "2019-05-05"
+    }
+  ],
+  "Spain": [
     {
       "annotation": {
         "pct_TP": "FF57",


### PR DESCRIPTION
Adding Canada and Spain: 
https://mozilla-hub.atlassian.net/browse/DENG-2894
https://mozilla-hub.atlassian.net/browse/DENG-2956
Setting content type: https://bugzilla.mozilla.org/show_bug.cgi?id=1506948

New countries need to be added to annotations because ensemble-transposer expects annotations for every country ([code](https://github.com/mozilla/ensemble-transposer/blob/5a233c175b6ff6b60331e986a10cc3f670c7b07c/src/formatters/Formatter.js#L24)).

Also set content-type to json so https://analysis-output.telemetry.mozilla.org/public-data-report/annotations/annotations_webusage.json and https://analysis-output.telemetry.mozilla.org/public-data-report/annotations/annotations_hardware.json render as json in firefox