### PR TITLE
Bug 1894036 - Avoid using "other" bucket for has_flash and os_arch

### DIFF
--- a/public_data_report/hardware_report/hardware_report.py
+++ b/public_data_report/hardware_report/hardware_report.py
@@ -270,14 +270,22 @@ def transform_dimensions(
 
 
 def collapse_buckets(aggregated_data, count_threshold, sample_count):
+    """Group keys that have less than count_threshold into an "Other" bucket."""
     OTHER_KEY = "Other"
+
+    # low-cardinality dimensions to not create an "other" bucket for
+    uncollapsed_dimensions = [
+        "has_flash",
+        "os_arch",
+    ]
+
     collapsed_groups = {}
     for dimension, counts in aggregated_data.items():
         collapsed_counts = {}
         for k, v in counts.items():
             if dimension == "resolution" and k == "0x0":
                 collapsed_counts[OTHER_KEY] = collapsed_counts.get(OTHER_KEY, 0) + v
-            elif v < count_threshold:
+            elif v < count_threshold and dimension not in uncollapsed_dimensions:
                 if dimension == "os":
                     # create generic key per os name
                     [os, ver] = k.split("-", 1)

--- a/tests/test_hardware_report.py
+++ b/tests/test_hardware_report.py
@@ -180,7 +180,7 @@ def test_collapse_buckets():
         "cpu_speed": {"3.6": 0.48, "Other": 0.52},
         "resolution": {"1920x1080": 1.0},
         "memory_gb": {"14": 0.5, "17": 0.5},
-        "has_flash": {"Other": 0.01, "False": 0.99},
+        "has_flash": {"True": 0.01, "False": 0.99},
         "os_arch": {"x86-64": 1.0},
         "gfx0_vendor_name": {"NVIDIA": 0.6, "Microsoft Basic": 0.4},
         "gfx0_model": {"Maxwell-GM204": 0.95, "Other": 0.05},


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1894036

The "true" value of has_flash just dropped below 1% so it became "Other".  This change makes it stay as "true".  os_arch is also added because it only has 32-bit and 64-bit with 32-bit slowly decreasing