### PR TITLE
Recognize Apple as GPU vendor

### DIFF
--- a/public_data_report/hardware_report/hardware_report.py
+++ b/public_data_report/hardware_report/hardware_report.py
@@ -135,6 +135,7 @@ def get_gpu_vendor_name(gpu_vendor_id):
         "0x15ad": "VMWare",
         "0x80ee": "Oracle VirtualBox",
         "0x1414": "Microsoft Basic",
+        "0x106b": "Apple",
     }
     return GPU_VENDOR_MAP.get(gpu_vendor_id, "Other")
 


### PR DESCRIPTION
Mysteriously Apple M1 reports device ID as null, but the vendor ID is still properly reported as 0x106b.