### PR TITLE
Update circleci image and orb (fixes #9)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 orbs:
-  gcp-gcr: circleci/gcp-gcr@0.7.1
+  gcp-gcr: circleci/gcp-gcr@0.16.2
 
 version: 2.1
 
 jobs:
   test:
     docker:
-      - image: mozilla/cidockerbases:docker-latest
+      - image: cimg/base:current  # https://circleci.com/developer/images/image/cimg/base
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
closes https://github.com/mozilla/firefox-public-data-report-etl/issues/9

Switching to the circleci base image which is a simple Ubuntu 22.04 (for now) image since the tests only need docker. https://circleci.com/developer/images/image/cimg/base