### PR TITLE
[DENG-3219] Remove sample multiplier from user activity MAU

### DIFF
--- a/public_data_report/user_activity/user_activity.py
+++ b/public_data_report/user_activity/user_activity.py
@@ -54,7 +54,7 @@ def main(bq_table, gcs_bucket, gcs_path):
                 "date": row.date,
                 "metrics": {
                     "avg_intensity": float(row.intensity),
-                    "MAU": row.mau * 100,
+                    "MAU": row.mau,
                     "avg_daily_usage(hours)": float(row.avg_hours_usage_daily),
                     "pct_new_user": float(row.new_profile_rate) * 100,
                     "pct_latest_version": float(row.latest_version_ratio) * 100,


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-3219

Goes with https://github.com/mozilla/bigquery-etl/pull/5905.  New MAU number is not a 1% sample