### PR TITLE
[DENG-9380] change docker repo URL

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -34,11 +34,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Build the Docker image
-        run: docker build . -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest
+        run: docker build . -t us-docker.pkg.dev/moz-fx-data-artifacts-prod/firefox-public-data-report-etl/firefox-public-data-report-etl:latest
       - name: Push Docker image to GAR
         uses: mozilla-it/deploy-actions/docker-push@v4.3.2
         with:
           project_id: moz-fx-data-artifacts-prod
-          image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/mozilla/firefox-public-data-report-etl:latest
+          image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/firefox-public-data-report-etl/firefox-public-data-report-etl:latest
           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
           service_account_name: github-actions-artifact-pusher


### PR DESCRIPTION
With https://github.com/mozilla/dataservices-infra/pull/1005 docker images should be pushed to their own GAR repo. Changing the URL to account for that