### PR TITLE
[DENG-9380] Update SA name to push image

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -41,4 +41,4 @@ jobs:
           project_id: moz-fx-data-artifacts-prod
           image_tags: us-docker.pkg.dev/moz-fx-data-artifacts-prod/firefox-public-data-report-etl/firefox-public-data-report-etl:latest
           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
-          service_account_name: github-actions-artifact-pusher
+          service_account_name: firefox-public-data-report-etl


### PR DESCRIPTION
Forgot to update the SA name. With the change in DENG-9380 we have separate service accounts per repo